### PR TITLE
chore: update to libdns/directadmin v0.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/caddyserver/caddy/v2 v2.6.4
-	github.com/libdns/directadmin v0.3.1-0.20240606140117-539d7a8d974d
+	github.com/libdns/directadmin v0.3.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/libdns/directadmin v0.3.1-0.20240606140117-539d7a8d974d h1:4MAISK+f7thAduQmvVJqU4GSI1z8eJXYXNKNzELH3uc=
-github.com/libdns/directadmin v0.3.1-0.20240606140117-539d7a8d974d/go.mod h1:VhiBrgenySGFsFUaESeTFBRmEnDHZ0Bek+AAZitrfYo=
+github.com/libdns/directadmin v0.3.2 h1:xX8DeaKOhs8JWKvzmq+Ggl88YVuYv66oxo+zKllKTPA=
+github.com/libdns/directadmin v0.3.2/go.mod h1:VhiBrgenySGFsFUaESeTFBRmEnDHZ0Bek+AAZitrfYo=
 github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
 github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=


### PR DESCRIPTION
Related to https://github.com/libdns/directadmin/pull/4